### PR TITLE
specific import error exception for stringIO

### DIFF
--- a/src/postomaat/core.py
+++ b/src/postomaat/core.py
@@ -40,7 +40,7 @@ import code
 from multiprocessing.reduction import ForkingPickler
 try:
    from StringIO import StringIO
-except:
+except ImportError:
    # Python 3
    from io import BytesIO as StringIO
 


### PR DESCRIPTION
import exception for StringIO should only catch the import error