### PR TITLE
color output, geoip conf example

### DIFF
--- a/conf/conf.d/geoip.conf.dist
+++ b/conf/conf.d/geoip.conf.dist
@@ -1,4 +1,4 @@
-[GeoIP]
+[GeoIPPlugin]
 # location of the MaxMind GeopIP database file
 database=/data/geoip/GeoIP.dat
 # list of countries you do not want to receive mail from.

--- a/src/postomaat/core.py
+++ b/src/postomaat/core.py
@@ -352,7 +352,7 @@ class MainController(object):
             print(fc.strcolor('At least one plugin failed to load','red'))
         print(fc.strcolor('Plugin loading complete','magenta'))
         
-        print("Linting ",fc.strcolor("main configuration",'cyan'))
+        print("Linting  "+fc.strcolor("main configuration",'cyan'))
         if not self.checkConfig():
             print(fc.strcolor("ERROR","red"))
         else:
@@ -364,7 +364,7 @@ class MainController(object):
         
         for plugin in allplugins:
             print("")
-            print("Linting Plugin ",fc.strcolor(str(plugin),'cyan'),'Config section:',fc.strcolor(str(plugin.section),'cyan'))
+            print("Linting Plugin "+fc.strcolor(str(plugin),'cyan')+'Config section: '+fc.strcolor(str(plugin.section),'cyan'))
             try:
                 result=plugin.lint()
             except Exception as e:

--- a/src/postomaat/scansession.py
+++ b/src/postomaat/scansession.py
@@ -133,12 +133,18 @@ class PolicydSession(object):
         self.closeconn()
 
     def closeconn(self):
-        # IMPORTANT: Shutdown the socket explicitly
-        #            before closing, otherwise the next
-        #            incoming connection in PolicyServer
-        #            might time-out in the socket.accept()
-        #            statement
-        self.socket.shutdown(socket.SHUT_RDWR)
+        if sys.version_info > (3,)
+            # IMPORTANT: Python 3
+            #            Shutdown the socket explicitly
+            #            before closing, otherwise the next
+            #            incoming connection in PolicyServer
+            #            might time-out in the socket.accept()
+            #            statement
+            #            -> seems to create problems for python 2.7.9
+            #               whereas it works with 2.7.5 where both versions
+            #               seem to work
+            #            -> decision: use only for python > 3
+            self.socket.shutdown(socket.SHUT_RDWR)
         self.socket.close()
 
     def getrequest(self):

--- a/src/startscript/postomaat
+++ b/src/startscript/postomaat
@@ -194,7 +194,7 @@ if lint or debugmsg:
     logging.basicConfig(level=level)
     
     fc=postomaat.funkyconsole.FunkyConsole()
-    print(fc.strcolor("postomaat", "yellow")+", ")
+    print(fc.strcolor("postomaat", "yellow"))
     print(fc.strcolor(POSTOMAAT_VERSION, "green"))
 
     # check if directory used by logfile exists

--- a/src/startscript/postomaat
+++ b/src/startscript/postomaat
@@ -194,7 +194,7 @@ if lint or debugmsg:
     logging.basicConfig(level=level)
     
     fc=postomaat.funkyconsole.FunkyConsole()
-    print(fc.strcolor("postomaat", "yellow"),)
+    print(fc.strcolor("postomaat", "yellow"))
     print(fc.strcolor(POSTOMAAT_VERSION, "green"))
 
     # check if directory used by logfile exists

--- a/src/startscript/postomaat
+++ b/src/startscript/postomaat
@@ -194,7 +194,7 @@ if lint or debugmsg:
     logging.basicConfig(level=level)
     
     fc=postomaat.funkyconsole.FunkyConsole()
-    print(fc.strcolor("postomaat", "yellow"))
+    print(fc.strcolor("postomaat", "yellow")+", ")
     print(fc.strcolor(POSTOMAAT_VERSION, "green"))
 
     # check if directory used by logfile exists


### PR DESCRIPTION
color output -> remove "," which screws up output printing postomaat header
geoinp configuration example file in conf.d was ignored since section asked by
postomaat name was incorrect